### PR TITLE
Fix bingx order placement and account retrieval

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -33,6 +33,9 @@ The updated `bot.py` is ready to deploy. No database migrations needed.
 ### 3. Start the Bot
 
 ```bash
+export ENHANCED_DB_PATH=/data/enhanced_trading_bot.db   # persist DB across restarts (Railway volume)
+export BINGX_API_KEY=...                                 # optional fallback, per-account keys preferred
+export BINGX_API_SECRET=...
 python3 bot.py
 ```
 
@@ -109,6 +112,14 @@ Check logs for these messages (every 5 seconds during polling):
 - Run the bot and manually start monitoring once
 - The configuration will be saved
 - Next restart should auto-start
+
+### Issue: Accounts not retrieved after redeploy
+
+**Check:**
+- Are you using a persistent SQLite path? The DB defaults to `enhanced_trading_bot.db` in CWD unless `ENHANCED_DB_PATH` or `DB_PATH` is set, or `/data` exists.
+
+**Fix:**
+- Set `ENHANCED_DB_PATH=/data/enhanced_trading_bot.db` (or mount a volume) before starting the bot so accounts persist across deployments.
 
 ### Issue: Messages not being detected
 


### PR DESCRIPTION
Implement per-account BingX trading and persistent account storage to enable channel-specific trade execution and prevent data loss on redeployment.

The bot now routes incoming trade signals to the correct trading account based on the channel where the message originated, using that account's specific BingX API keys for trade execution. Additionally, the SQLite database path is now configurable and defaults to a persistent volume (e.g., `/data`) to ensure account data is not lost when the bot restarts.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a4bbb16-5e5a-4f02-a32c-dbb7acb9ede8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a4bbb16-5e5a-4f02-a32c-dbb7acb9ede8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

