### PR TITLE
Fix account retrieval after redeployment

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -118,7 +118,13 @@ Check logs for these messages (every 5 seconds during polling):
 **Check:**
 - Are you using a persistent SQLite path? The DB defaults to `enhanced_trading_bot.db` in CWD unless `ENHANCED_DB_PATH` or `DB_PATH` is set, or `/data` exists.
 
-**Fix:**
+**Fix for Railway.com:**
+- Railway uses ephemeral storage by default - all data is lost on redeployment!
+- **You MUST set up a Railway Volume for persistent storage**
+- See [RAILWAY_SETUP.md](./RAILWAY_SETUP.md) for complete Railway configuration guide
+- Quick fix: Add a volume mounted at `/data` and set `ENHANCED_DB_PATH=/data/enhanced_trading_bot.db`
+
+**Fix for other platforms:**
 - Set `ENHANCED_DB_PATH=/data/enhanced_trading_bot.db` (or mount a volume) before starting the bot so accounts persist across deployments.
 
 ### Issue: Messages not being detected

--- a/QUICK_FIX_RAILWAY.md
+++ b/QUICK_FIX_RAILWAY.md
@@ -1,0 +1,71 @@
+# 🚀 Quick Fix: Accounts Not Persisting on Railway
+
+## Problem
+After redeploying on Railway.com, all your accounts disappear.
+
+## Root Cause
+Railway uses **ephemeral storage** - the filesystem is wiped on every deployment. Your SQLite database with all accounts is lost!
+
+---
+
+## ✅ Solution (5 minutes)
+
+### Step 1: Add a Railway Volume
+1. Open your Railway project
+2. Click on your bot service
+3. Go to **Settings** → **Volumes**
+4. Click **"+ New Volume"**
+5. Set:
+   - **Mount Path**: `/data`
+   - Click **"Add"**
+
+### Step 2: Set Environment Variable
+1. Still in your service settings, go to **Variables**
+2. Click **"+ New Variable"**
+3. Add:
+   ```
+   ENHANCED_DB_PATH=/data/enhanced_trading_bot.db
+   ```
+4. Click **"Add"**
+
+### Step 3: Redeploy
+Railway will automatically redeploy. Your accounts will now persist! ✨
+
+---
+
+## ⚠️ Important Note
+
+After the first deployment with the volume:
+- You'll have **0 accounts** (the old database was in ephemeral storage and is gone)
+- You need to **re-add your accounts** once through the bot
+- From then on, they'll persist across all future deployments
+
+---
+
+## Verification
+
+Check your Railway logs after deployment:
+
+```
+✅ Database path: /data/enhanced_trading_bot.db
+📊 Ready! Use PIN code XXXXXX to access
+```
+
+If you see this, you're good! The database is now on persistent storage.
+
+---
+
+## Need More Details?
+
+See [RAILWAY_SETUP.md](./RAILWAY_SETUP.md) for the complete guide with troubleshooting.
+
+---
+
+## Alternative: Use Railway PostgreSQL (Advanced)
+
+Instead of SQLite + Volume, you could migrate to PostgreSQL:
+1. Add Railway PostgreSQL service
+2. Modify bot.py to use PostgreSQL instead of SQLite
+3. More robust for production
+
+But the volume solution above is simpler and works perfectly for this use case!

--- a/RAILWAY_SETUP.md
+++ b/RAILWAY_SETUP.md
@@ -1,0 +1,192 @@
+# Railway.com Persistent Storage Setup
+
+## The Problem
+
+Railway deployments use **ephemeral storage** by default, meaning the filesystem gets wiped on every deployment. This causes:
+- ❌ All accounts lost after redeployment
+- ❌ Session files (.session) lost
+- ❌ Database wiped clean
+
+## The Solution: Railway Volumes
+
+Railway Volumes provide **persistent storage** that survives deployments.
+
+---
+
+## Step-by-Step Setup
+
+### 1. Create a Railway Volume
+
+1. Go to your Railway project dashboard
+2. Click on your service (the bot)
+3. Go to the **"Variables"** tab
+4. Scroll down and click **"+ New Volume"**
+5. Configure the volume:
+   - **Mount Path**: `/data`
+   - **Size**: 1 GB (minimum, adjust as needed)
+6. Click **"Add"**
+
+### 2. Set Environment Variables
+
+In your Railway project, add these environment variables:
+
+```bash
+ENHANCED_DB_PATH=/data/enhanced_trading_bot.db
+```
+
+**Optional but recommended:**
+```bash
+# Your other environment variables
+BINGX_API_KEY=your_api_key
+BINGX_API_SECRET=your_api_secret
+# ... any other vars you need
+```
+
+### 3. Redeploy
+
+After adding the volume and environment variable:
+1. Railway will automatically redeploy
+2. The bot will now store data in `/data/` which persists across deployments
+
+---
+
+## Verification
+
+After redeployment, check your Railway logs for:
+
+```
+✅ Database path: /data/enhanced_trading_bot.db
+📊 Ready! Use PIN code XXXXXX to access
+✅ Retrieved N accounts from database
+```
+
+If you see "Retrieved 0 accounts", it's normal for the **first** deployment after setting up the volume (your old accounts were in the ephemeral storage and are lost).
+
+---
+
+## Migration: Recovering Existing Accounts
+
+If you have accounts configured but they're being lost, you have two options:
+
+### Option A: Re-add Accounts (Recommended)
+
+1. After setting up the volume and redeploying, use the bot to add your accounts again
+2. They will now persist across deployments
+
+### Option B: Manual Database Migration (Advanced)
+
+If you can access your old database before it gets wiped:
+
+1. **Before redeployment**, download the current database:
+   ```bash
+   # Using Railway CLI
+   railway connect
+   cat enhanced_trading_bot.db > /tmp/backup.db
+   exit
+   ```
+
+2. **After** setting up the volume and redeploying:
+   ```bash
+   # Upload the database to the volume
+   railway connect
+   cat /tmp/backup.db > /data/enhanced_trading_bot.db
+   exit
+   
+   # Restart the service
+   railway restart
+   ```
+
+---
+
+## Session Files Persistence
+
+The bot also creates `.session` files for Telegram connections. These should also be stored in the persistent volume.
+
+If session files are stored separately, you may also want to:
+
+```bash
+# Move session files to persistent storage
+TELEGRAM_SESSION_PATH=/data/
+```
+
+Check `bot.py` for session file handling and ensure they're stored in `/data/` as well.
+
+---
+
+## Troubleshooting
+
+### "Retrieved 0 accounts after setup"
+
+**This is normal** if:
+- First time setting up the volume
+- The old database was in ephemeral storage
+
+**Fix**: Re-add your accounts through the bot interface. They will now persist.
+
+### "Database locked" error
+
+Railway might not be properly mounting the volume.
+
+**Fix**: 
+1. Verify the volume is created and mounted at `/data`
+2. Check Railway dashboard for volume status
+3. Try restarting the service
+
+### Volume not showing up
+
+**Check**:
+1. Make sure you're on a Railway plan that supports volumes (not all do)
+2. Verify the volume is attached to the correct service
+3. Check Railway status page for any issues
+
+---
+
+## Important Notes
+
+⚠️ **Backup Your Database Regularly**
+
+Even with persistent volumes, you should backup your database:
+
+```bash
+# Using Railway CLI
+railway connect
+cp /data/enhanced_trading_bot.db /data/backup_$(date +%Y%m%d).db
+# Or download it
+railway volume get /data/enhanced_trading_bot.db
+```
+
+⚠️ **Volume Size**
+
+- Start with 1 GB
+- Monitor usage in Railway dashboard
+- Increase if needed (though SQLite databases are typically small)
+
+⚠️ **Cost**
+
+- Railway volumes have associated costs
+- Check Railway pricing for current rates
+- Usually very affordable for small databases (<1 GB)
+
+---
+
+## Quick Reference
+
+| Item | Value |
+|------|-------|
+| Volume Mount Path | `/data` |
+| Environment Variable | `ENHANCED_DB_PATH=/data/enhanced_trading_bot.db` |
+| Database File | `enhanced_trading_bot.db` |
+| Full Path | `/data/enhanced_trading_bot.db` |
+
+---
+
+## Next Steps
+
+After setting up persistent storage:
+
+1. ✅ Add your trading accounts back to the bot
+2. ✅ Configure your monitored channels
+3. ✅ Test with a sample signal
+4. ✅ Verify accounts persist after redeployment
+
+See [DEPLOYMENT_GUIDE.md](./DEPLOYMENT_GUIDE.md) for testing procedures.

--- a/railway.json
+++ b/railway.json
@@ -1,8 +1,11 @@
 {
+  "$schema": "https://railway.app/railway.schema.json",
   "build": {
     "builder": "NIXPACKS"
   },
   "deploy": {
-    "startCommand": "python bot.py"
+    "startCommand": "python bot.py",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
   }
 }


### PR DESCRIPTION
Add Railway.com persistent storage configuration and documentation to prevent account data loss.

Railway's default filesystem is ephemeral, causing the SQLite database (and thus all accounts) to be wiped on every redeployment. This PR introduces guides and configuration to leverage Railway Volumes for persistent storage.

---
<a href="https://cursor.com/background-agent?bcId=bc-c50d7478-9284-4039-9db4-6d9a0f1e4d66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c50d7478-9284-4039-9db4-6d9a0f1e4d66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

