### PR TITLE
Fix trading bot set app setting error

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6085,9 +6085,9 @@ async def auto_start_monitoring():
                     logger.info(f"   Account: {account.account_name}")
                     logger.info(f"   Channels: {account.monitored_channels}")
                     
-                    # Set the current account for this user and bind exchange client
-                    trading_bot.set_current_account(account.user_id, account.account_id)
-                    trading_bot.set_app_setting(f'current_account_{account.user_id}', account.account_id)
+                # Set the current account for this user and bind exchange client
+                trading_bot.set_current_account(account.user_id, account.account_id)
+                trading_bot.enhanced_db.set_app_setting(f'current_account_{account.user_id}', account.account_id)
                     
                     # Get the bot application
                     bot_app = trading_bot.bot_instances.get(account.user_id)


### PR DESCRIPTION
Fix `AttributeError: 'TradingBot' object has no attribute 'set_app_setting'` by calling the method on the correct `enhanced_db` object.

---
<a href="https://cursor.com/background-agent?bcId=bc-87398dc1-92db-43f4-b831-eba0a9f91202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87398dc1-92db-43f4-b831-eba0a9f91202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

