### PR TITLE
Fix bot startup and warnings

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6003,7 +6003,8 @@ channel_conv_handler = ConversationHandler(
         WAITING_MANUAL_CHANNEL: [MessageHandler(filters.TEXT & ~filters.COMMAND, handle_manual_channel)],
         WAITING_CHANNEL_LINK: [MessageHandler(filters.TEXT & ~filters.COMMAND, handle_channel_link)],
     },
-    fallbacks=[CommandHandler('cancel', lambda u, c: ConversationHandler.END)]
+    fallbacks=[CommandHandler('cancel', lambda u, c: ConversationHandler.END)],
+    per_message=True
 )
 
 trading_conv_handler = ConversationHandler(
@@ -6024,7 +6025,8 @@ trading_conv_handler = ConversationHandler(
         WAITING_TP_LEVEL_PERCENT: [MessageHandler(filters.TEXT & ~filters.COMMAND, handle_tp_level_percent)],
         WAITING_TP_LEVEL_CLOSE: [MessageHandler(filters.TEXT & ~filters.COMMAND, handle_tp_level_close)],
     },
-    fallbacks=[CommandHandler('cancel', lambda u, c: ConversationHandler.END)]
+    fallbacks=[CommandHandler('cancel', lambda u, c: ConversationHandler.END)],
+    per_message=True
 )
 
 # Enhanced account conversation handler


### PR DESCRIPTION
Add `per_message=True` to ConversationHandlers to resolve `PTBUserWarning` for `CallbackQueryHandler`.

---
<a href="https://cursor.com/background-agent?bcId=bc-24d4bd90-ebc1-4949-bac9-a0593f022cf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24d4bd90-ebc1-4949-bac9-a0593f022cf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

