### PR TITLE
Initialize and start trading bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6004,7 +6004,7 @@ channel_conv_handler = ConversationHandler(
         WAITING_CHANNEL_LINK: [MessageHandler(filters.TEXT & ~filters.COMMAND, handle_channel_link)],
     },
     fallbacks=[CommandHandler('cancel', lambda u, c: ConversationHandler.END)],
-    per_message=True
+    per_message=False
 )
 
 trading_conv_handler = ConversationHandler(
@@ -6026,7 +6026,7 @@ trading_conv_handler = ConversationHandler(
         WAITING_TP_LEVEL_CLOSE: [MessageHandler(filters.TEXT & ~filters.COMMAND, handle_tp_level_close)],
     },
     fallbacks=[CommandHandler('cancel', lambda u, c: ConversationHandler.END)],
-    per_message=True
+    per_message=False
 )
 
 # Enhanced account conversation handler


### PR DESCRIPTION
Change `per_message` to `False` in `ConversationHandler` configurations to resolve `PTBUserWarning` when using `MessageHandler`.

The `PTBUserWarning` occurs because `per_message=True` in `ConversationHandler` expects all entry points, state handlers, and fallbacks to be `CallbackQueryHandler`. Since these handlers also use `MessageHandler`, setting `per_message=False` (the default) correctly configures them to handle both message and callback query contexts.

---
<a href="https://cursor.com/background-agent?bcId=bc-407156a4-2656-4ff9-a35b-d0e5f6112ad0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-407156a4-2656-4ff9-a35b-d0e5f6112ad0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

